### PR TITLE
fix for <unknown>:1: SyntaxWarning: invalid escape sequence '\d'

### DIFF
--- a/lbl_rpt_watcher/lbl_rpt_watcher.py
+++ b/lbl_rpt_watcher/lbl_rpt_watcher.py
@@ -49,7 +49,7 @@ def save_data_store_to_disc(config, data_store):
 def eval_text (text):
     data={}
     try:
-        t = literal_eval(text[9:])
+        t = literal_eval(text)
         if t[0] == "MOO":
             if "SCORE_BOARD" in t[2]:
                 data["date_stamp"] = str(t[1][0])


### PR DESCRIPTION
Removing first 9 symbols from each line to clean it from timestamp. was a mistake, lines put in .rpt by lbl doesn't have timestamp.